### PR TITLE
Add headless install options

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -1,7 +1,7 @@
 {% set pyproject = load_file_data('../pyproject.toml', from_recipe_dir=True) %}
 {% set project = pyproject.get('project') %}
 {% set urls = pyproject.get('project', {}).get('urls') %}
-{% set version = environ.get('BUILD_VERSION', '0.4.2a0') %}
+{% set version = environ.get('BUILD_VERSION', '0.5.0a0') %}
 
 package:
   name: onnxtr

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[cpu,viz] --upgrade
+          pip install -e .[cpu-headless,viz] --upgrade
       - name: Import package
         run: python -c "import onnxtr; print(onnxtr.__version__)"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         # Must match version at https://www.python.org/ftp/python/
         python: ["3.10.13"]
-        system: ["cpu", "gpu"]
+        system: ["cpu-headless", "gpu-headless"]
 
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[cpu,viz,html,testing] --upgrade
+          pip install -e .[cpu-headless,viz,html,testing] --upgrade
       - name: Run unittests
         run: |
           coverage run -m pytest tests/common/ -rs

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov](https://codecov.io/gh/felixdittrich92/OnnxTR/graph/badge.svg?token=WVFRCQBOLI)](https://codecov.io/gh/felixdittrich92/OnnxTR)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/4fff4d764bb14fb8b4f4afeb9587231b)](https://app.codacy.com/gh/felixdittrich92/OnnxTR/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![CodeFactor](https://www.codefactor.io/repository/github/felixdittrich92/onnxtr/badge)](https://www.codefactor.io/repository/github/felixdittrich92/onnxtr)
-[![Pypi](https://img.shields.io/badge/pypi-v0.4.1-blue.svg)](https://pypi.org/project/OnnxTR/)
+[![Pypi](https://img.shields.io/badge/pypi-v0.5.0-blue.svg)](https://pypi.org/project/OnnxTR/)
 
 > :warning: Please note that this is a wrapper around the [doctr](https://github.com/mindee/doctr) library to provide a Onnx pipeline for docTR. For feature requests, which are not directly related to the Onnx pipeline, please refer to the base project.
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ For GPU support please take a look at: [ONNX Runtime](https://onnxruntime.ai/get
 
 ```shell
 pip install "onnxtr[cpu]"
+pip install "onnxtr[cpu-headless]"  # same as cpu but with opencv-headless
 # with gpu support
 pip install "onnxtr[gpu]"
+pip install "onnxtr[gpu-headless]"  # same as gpu but with opencv-headless
 # with HTML support
 pip install "onnxtr[html]"
 # with support for visualization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     # Additional typing support is brought by numpy>=1.22.4, but core build sticks to >=1.16.0
     "numpy>=1.16.0,<3.0.0",
     "scipy>=1.4.0,<2.0.0",
-    "opencv-python>=4.5.0,<5.0.0",
     "pypdfium2>=4.11.0,<5.0.0",
     "pyclipper>=1.2.0,<2.0.0",
     "shapely>=1.6.0,<3.0.0",
@@ -49,9 +48,19 @@ dependencies = [
 [project.optional-dependencies]
 cpu = [
     "onnxruntime>=1.11.0",
+    "opencv-python>=4.5.0,<5.0.0",
 ]
 gpu = [
     "onnxruntime-gpu>=1.11.0",
+    "opencv-python>=4.5.0,<5.0.0",
+]
+cpu-headless = [
+    "onnxruntime>=1.11.0",
+    "opencv-python-headless>=4.5.0,<5.0.0",
+]
+gpu-headless = [
+    "onnxruntime-gpu>=1.11.0",
+    "opencv-python-headless>=4.5.0,<5.0.0",
 ]
 html = [
     "weasyprint>=55.0",
@@ -73,6 +82,7 @@ quality = [
 dev = [
     # Runtime
     "onnxruntime>=1.11.0",
+    "opencv-python>=4.5.0,<5.0.0",
     # HTML
     "weasyprint>=55.0",
     # Visualization

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from setuptools import setup
 
 PKG_NAME = "onnxtr"
-VERSION = os.getenv("BUILD_VERSION", "0.4.2a0")
+VERSION = os.getenv("BUILD_VERSION", "0.5.0a0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:

- Add "headless" install options as mentioned in #34 
- Update docker to headless
- CI: Run tests on "headless" instead of full -> if it runs with headless it will also run with non-headless