### PR TITLE
[Fix] pathlib issue windows with older onnxruntime versions

### DIFF
--- a/onnxtr/models/engine.py
+++ b/onnxtr/models/engine.py
@@ -90,6 +90,8 @@ class Engine:
     def __init__(self, url: str, engine_cfg: EngineConfig | None = None, **kwargs: Any) -> None:
         engine_cfg = engine_cfg if isinstance(engine_cfg, EngineConfig) else EngineConfig()
         archive_path = download_from_url(url, cache_subdir="models", **kwargs) if "http" in url else url
+        # NOTE: older onnxruntime versions require a string path for windows
+        archive_path = rf"{archive_path}"
         # Store model path for each model
         self.model_path = archive_path
         self.session_options = engine_cfg.session_options


### PR DESCRIPTION
This PR:

- transform to string if pathlib Path object which raises issues on windows with older onnxruntime versions