### PR TITLE
Add run_options_provider for EngineConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,32 @@ predictor = ocr_predictor(
 )
 ```
 
+You can also dynamically configure whether the memory arena should shrink:
+
+```python
+from random import random
+from onnxruntime import RunOptions, SessionOptions
+
+from onnxtr.models import ocr_predictor, EngineConfig
+
+def arena_shrinkage_handler(run_options: RunOptions) -> RunOptions:
+  """
+  Shrink the memory arena on 10% of inference runs.
+  """
+  if random() < 0.1:
+    run_options.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0")
+  return run_options
+
+engine_config = EngineConfig(run_options_provider=arena_shrinkage_handler)
+engine_config.session_options.enable_mem_pattern = False
+
+predictor = ocr_predictor(
+    det_engine_cfg=engine_config,
+    reco_engine_cfg=engine_config,
+    clf_engine_cfg=engine_config
+)
+```
+
 </details>
 
 ## Loading custom exported models

--- a/onnxtr/models/engine.py
+++ b/onnxtr/models/engine.py
@@ -5,7 +5,8 @@
 
 import logging
 import os
-from typing import Any, Callable, TypeAlias
+from collections.abc import Callable
+from typing import Any, TypeAlias
 
 import numpy as np
 from onnxruntime import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ testing = [
     "coverage[toml]>=4.5.4",
     "requests>=2.20.0",
     "pytest-memray>=1.7.0",
+    "psutil>=7.0.0",
 ]
 quality = [
     "ruff>=0.1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ dev = [
     "coverage[toml]>=4.5.4",
     "requests>=2.20.0",
     "pytest-memray>=1.7.0",
+    "psutil>=7.0.0",
     # Quality
     "ruff>=0.1.5",
     "mypy>=0.812",

--- a/tests/common/test_engine_cfg.py
+++ b/tests/common/test_engine_cfg.py
@@ -93,7 +93,6 @@ def test_cpu_memory_arena_shrinkage_enabled():
     providers = [("CPUExecutionProvider", {"arena_extend_strategy": "kSameAsRequested"})]
 
     def enable_arena_shrinkage(run_options: "RunOptions") -> "RunOptions":
-        nonlocal enable_shrinkage
         if enable_shrinkage:
             run_options.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0")
             assert run_options.get_run_config_entry("memory.enable_memory_arena_shrinkage") == "cpu:0"

--- a/tests/common/test_engine_cfg.py
+++ b/tests/common/test_engine_cfg.py
@@ -1,11 +1,20 @@
+import gc
+
 import numpy as np
+import psutil
 import pytest
-from onnxruntime import SessionOptions
+from onnxruntime import RunOptions, SessionOptions
 
 from onnxtr import models
 from onnxtr.io import Document
 from onnxtr.models import EngineConfig, detection, recognition
 from onnxtr.models.predictor import OCRPredictor
+
+
+def _get_rss_mb():
+    gc.collect()
+    process = psutil.Process()
+    return process.memory_info().rss / (1024 * 1024)
 
 
 def _test_predictor(predictor):
@@ -72,3 +81,55 @@ def test_engine_cfg(det_arch, reco_arch):
     reco_predictor = models.recognition_predictor(reco_arch, engine_cfg=engine_cfg)
     assert reco_predictor.model.providers == ["CPUExecutionProvider"]
     assert not reco_predictor.model.session_options.enable_cpu_mem_arena
+
+
+def test_cpu_memory_arena_shrinkage_enabled():
+    session_options = SessionOptions()
+    session_options.enable_mem_pattern = False
+    session_options.enable_cpu_mem_arena = True
+
+    enable_shrinkage = False
+
+    providers = [("CPUExecutionProvider", {"arena_extend_strategy": "kSameAsRequested"})]
+
+    def enable_arena_shrinkage(run_options: "RunOptions") -> "RunOptions":
+        nonlocal enable_shrinkage
+        if enable_shrinkage:
+            run_options.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0")
+            assert run_options.get_run_config_entry("memory.enable_memory_arena_shrinkage") == "cpu:0"
+        return run_options
+
+    engine_cfg = EngineConfig(
+        providers=providers,
+        session_options=session_options,
+        run_options_provider=enable_arena_shrinkage,
+    )
+
+    predictor = models.ocr_predictor(
+        det_engine_cfg=engine_cfg,
+        reco_engine_cfg=engine_cfg,
+        clf_engine_cfg=engine_cfg,
+        detect_orientation=True,
+    )
+
+    assert predictor.det_predictor.model.providers == providers
+    assert predictor.det_predictor.model.session_options.enable_cpu_mem_arena
+    assert predictor.reco_predictor.model.providers == providers
+    assert predictor.reco_predictor.model.session_options.enable_cpu_mem_arena
+
+    rng = np.random.RandomState(seed=42)
+    sample = rng.randint(0, 256, (1024, 1024, 3), dtype=np.uint8)
+
+    start_rss = _get_rss_mb()
+
+    predictor([sample])
+    increased_rss = _get_rss_mb()
+
+    assert increased_rss - start_rss > 100
+
+    enable_shrinkage = True
+
+    predictor([sample])
+    decreased_rss = _get_rss_mb()
+
+    assert increased_rss - decreased_rss > 100

--- a/tests/common/test_engine_cfg.py
+++ b/tests/common/test_engine_cfg.py
@@ -124,11 +124,11 @@ def test_cpu_memory_arena_shrinkage_enabled():
     predictor([sample])
     increased_rss = _get_rss_mb()
 
-    assert increased_rss - start_rss > 100
+    assert increased_rss > start_rss
 
     enable_shrinkage = True
 
     predictor([sample])
     decreased_rss = _get_rss_mb()
 
-    assert increased_rss - decreased_rss > 100
+    assert increased_rss > decreased_rss


### PR DESCRIPTION
Pull request context: https://github.com/felixdittrich92/OnnxTR/issues/78

This adds a new `run_options_provider` to `EngineConfig` that dynamically updates the `run_options` for inference on every model.

### Example:

```py
def arena_shrinkage_handler(run_options: RunOptions) -> RunOptions:
  """
  Shrink the memory arena on 10% of inference runs.
  """
  if math.random() < 0.1:
    run_options.add_run_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0")
  return run_options

engine_config = EngineConfig(run_options_provider=arena_shrinkage_handler)
engine_config.session_options.enable_mem_pattern = False
```