### PR TITLE
[sync] Port whitelisting feature

### DIFF
--- a/onnxtr/file_utils.py
+++ b/onnxtr/file_utils.py
@@ -8,6 +8,8 @@ import logging
 
 __all__ = ["requires_package"]
 
+logger = logging.getLogger(__name__)
+
 ENV_VARS_TRUE_VALUES = {"1", "ON", "YES", "TRUE"}
 ENV_VARS_TRUE_AND_AUTO_VALUES = ENV_VARS_TRUE_VALUES.union({"AUTO"})
 
@@ -22,7 +24,7 @@ def requires_package(name: str, extra_message: str | None = None) -> None:  # pr
     """
     try:
         _pkg_version = importlib.metadata.version(name)
-        logging.info(f"{name} version {_pkg_version} available.")
+        logger.info(f"{name} version {_pkg_version} available.")
     except importlib.metadata.PackageNotFoundError:
         raise ImportError(
             f"\n\n{extra_message if extra_message is not None else ''} "

--- a/onnxtr/models/__init__.py
+++ b/onnxtr/models/__init__.py
@@ -7,3 +7,4 @@ from .recognition import *
 from .zoo import *
 from .factory import *
 from .reading_order import *
+from .utils import *

--- a/onnxtr/models/detection/models/fast.py
+++ b/onnxtr/models/detection/models/fast.py
@@ -14,6 +14,8 @@ from ..postprocessor.base import GeneralDetectionPostProcessor
 
 __all__ = ["FAST", "fast_tiny", "fast_small", "fast_base"]
 
+logger = logging.getLogger(__name__)
+
 
 default_cfgs: dict[str, dict[str, Any]] = {
     "fast_tiny": {
@@ -96,7 +98,7 @@ def _fast(
     **kwargs: Any,
 ) -> FAST:
     if load_in_8_bit:
-        logging.warning("FAST models do not support 8-bit quantization yet. Loading full precision model...")
+        logger.warning("FAST models do not support 8-bit quantization yet. Loading full precision model...")
     # Build the model
     return FAST(model_path, cfg=default_cfgs[arch], engine_cfg=engine_cfg, **kwargs)
 

--- a/onnxtr/models/engine.py
+++ b/onnxtr/models/engine.py
@@ -27,6 +27,8 @@ from onnxtr.utils.geometry import shape_translate
 
 __all__ = ["EngineConfig", "RunOptionsProvider"]
 
+logger = logging.getLogger(__name__)
+
 RunOptionsProvider: TypeAlias = Callable[[RunOptions], RunOptions]
 
 _ORT_TO_NUMPY_DTYPE: dict[str, Any] = {
@@ -69,7 +71,7 @@ class EngineConfig:
     def _init_providers(self) -> list[tuple[str, dict[str, Any]]]:
         providers: Any = [("CPUExecutionProvider", {"arena_extend_strategy": "kSameAsRequested"})]
         available_providers = get_available_providers()
-        logging.info(f"Available providers: {available_providers}")
+        logger.info(f"Available providers: {available_providers}")
         if "CUDAExecutionProvider" in available_providers and get_device() == "GPU":  # pragma: no cover
             providers.insert(
                 0,

--- a/onnxtr/models/layout/models/lw_detr.py
+++ b/onnxtr/models/layout/models/lw_detr.py
@@ -15,6 +15,7 @@ from ..postprocessor.base import LWDETRPostProcessor
 
 __all__ = ["LWDETR", "lw_detr_s"]  # , "lw_detr_m"] --- IGNORE ---
 
+logger = logging.getLogger(__name__)
 
 CLASS_NAMES = [
     "Caption",
@@ -145,7 +146,7 @@ def _lw_detr(
         raise ValueError(f"no pretrained ONNX export is available for '{arch}' yet")
     if load_in_8_bit:
         if default_cfgs[arch]["url_8_bit"] is None:
-            logging.warning(f"No 8-bit quantized export available for '{arch}'. Loading full precision model...")
+            logger.warning(f"No 8-bit quantized export available for '{arch}'. Loading full precision model...")
         elif "http" in model_path:
             model_path = default_cfgs[arch]["url_8_bit"]
     # Build the model

--- a/onnxtr/models/recognition/models/viptr.py
+++ b/onnxtr/models/recognition/models/viptr.py
@@ -18,6 +18,8 @@ from ..core import RecognitionPostProcessor
 
 __all__ = ["VIPTR", "viptr_tiny"]
 
+logger = logging.getLogger(__name__)
+
 default_cfgs: dict[str, dict[str, Any]] = {
     "viptr_tiny": {
         "mean": (0.694, 0.695, 0.693),
@@ -139,7 +141,7 @@ def _viptr(
     **kwargs: Any,
 ) -> VIPTR:
     if load_in_8_bit:
-        logging.warning("VIPTR models do not support 8-bit quantization yet. Loading full precision model...")
+        logger.warning("VIPTR models do not support 8-bit quantization yet. Loading full precision model...")
     kwargs["vocab"] = kwargs.get("vocab", default_cfgs[arch]["vocab"])
 
     _cfg = deepcopy(default_cfgs[arch])

--- a/onnxtr/models/table_structure/models/tablecenternet.py
+++ b/onnxtr/models/table_structure/models/tablecenternet.py
@@ -19,6 +19,8 @@ from ..postprocessor.base import TableCenterNetPostProcessor
 
 __all__ = ["TableCenterNet", "tablecenternet"]
 
+logger = logging.getLogger(__name__)
+
 # The order the heads are written by docTR's ONNX export
 HEAD_NAMES = ["hm", "reg", "ct2cn", "cn2ct", "lc", "sp"]
 
@@ -236,7 +238,7 @@ def _tablecenternet(
 ) -> TableCenterNet:
     if load_in_8_bit:
         if default_cfgs[arch]["url_8_bit"] is None:
-            logging.warning(f"No 8-bit quantized export available for '{arch}'. Loading full precision model...")
+            logger.warning(f"No 8-bit quantized export available for '{arch}'. Loading full precision model...")
         elif "http" in model_path:
             model_path = default_cfgs[arch]["url_8_bit"]
     # Build the model

--- a/onnxtr/models/utils.py
+++ b/onnxtr/models/utils.py
@@ -1,0 +1,333 @@
+# Copyright (C) 2021-2026, Mindee | Felix Dittrich.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+import numpy as np
+from anyascii import anyascii
+
+__all__ = ["WhitelistHandle", "add_whitelist"]
+
+logger = logging.getLogger(__name__)
+
+# Initializer names of the final vocabulary projection, per recognition architecture.
+# Only used to disambiguate when several initializers could match; the search falls back to
+# shape-based detection for anything not listed here.
+_PROJECTION_HINTS: tuple[str, ...] = ("head.weight", "linear", "output_dense", "head", "fc", "classifier")
+
+
+class WhitelistHandle:
+    """Removable registration returned by :func:`add_whitelist`.
+
+    Call :meth:`remove` to restore the model's original, unconstrained decoding. The
+    handle can also be used as a context manager, in which case the whitelist is removed
+    on exit.
+    """
+
+    def __init__(self, restore: list[tuple[Any, Any]]) -> None:
+        self._restore = restore
+
+    def remove(self) -> None:
+        """Restore the original, unconstrained decoding"""
+        for model, postprocessor in self._restore:
+            model.postprocessor = postprocessor
+        self._restore = []
+
+    def __enter__(self) -> "WhitelistHandle":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.remove()
+
+
+class _ConstrainedPostProcessor:
+    """Wraps a recognition post-processor and constrains the logits before they are decoded.
+
+    docTR enforces the whitelist with a forward hook on the model's final projection layer.
+    An ONNX graph exposes no such hook, but every OnnxTR recognition architecture funnels its
+    raw logits through ``self.postprocessor(logits)``, so wrapping that call is the equivalent
+    single choke point - and it is just as removable.
+    """
+
+    def __init__(self, postprocessor: Any, keep: np.ndarray, src: np.ndarray, dst: np.ndarray) -> None:
+        self.postprocessor = postprocessor
+        self.keep = keep
+        self.src = src
+        self.dst = dst
+
+    def __call__(self, logits: np.ndarray, *args: Any, **kwargs: Any) -> Any:
+        return self.postprocessor(self._constrain(logits), *args, **kwargs)
+
+    def _constrain(self, logits: np.ndarray) -> np.ndarray:
+        output = np.array(logits, dtype=np.float32, copy=True)
+        if self.src.size:
+            # move each forbidden character's score onto its nearest allowed character.
+            # Several forbidden characters can share a target, so the maximum is taken.
+            for target in np.unique(self.dst):
+                sources = self.src[self.dst == target]
+                output[..., target] = np.maximum(output[..., target], output[..., sources].max(axis=-1))
+        output[..., ~self.keep] = -np.inf
+        return output
+
+    def __getattr__(self, name: str) -> Any:
+        # stay transparent for callers reaching for e.g. `postprocessor.vocab`
+        return getattr(self.__dict__["postprocessor"], name)
+
+
+def _recognition_models(model: Any) -> list[Any]:
+    """Collect the recognition model(s) a whitelist should be applied to
+
+    Accepts an ``ocr_predictor``, a ``recognition_predictor`` or a bare recognition model.
+    """
+    # a recognition model itself
+    if hasattr(model, "cfg") and isinstance(getattr(model, "cfg", None), dict) and "vocab" in (model.cfg or {}):
+        return [model]
+    reco_predictor = getattr(model, "reco_predictor", model)
+    reco_model = getattr(reco_predictor, "model", None)
+    if reco_model is None:
+        raise TypeError(
+            "Expected an ocr_predictor, recognition_predictor or a recognition model, but could "
+            f"not find a recognition model on {type(model).__name__}."
+        )
+    return [reco_model]
+
+
+def _anyascii_nearest_map(vocab: str, allowed: set[str]) -> dict[str, str]:
+    """Map each forbidden character to the visually closest allowed one via transliteration.
+
+    Uses `anyascii` to fold characters to their ASCII form (e.g. `ä -> a`, `ł -> l`,
+    Cyrillic `а -> a`); a forbidden character is mapped to an allowed character sharing the
+    same ASCII form. Forbidden characters without such a match are left unmapped (they fall
+    back to plain masking).
+    """
+    by_translit: dict[str, str] = {}
+    for char in vocab:
+        if char not in allowed:
+            continue
+        key = anyascii(char)
+        current = by_translit.get(key)
+        # Prefer a pure-ASCII allowed character as the canonical target for a given form.
+        if current is None or (char == anyascii(char) and current != anyascii(current)):
+            by_translit[key] = char
+
+    mapping: dict[str, str] = {}
+    for char in vocab:
+        if char in allowed:
+            continue
+        form = anyascii(char)
+        target = by_translit.get(form) or by_translit.get(form.lower()) or by_translit.get(form[:1])
+        if target is not None:
+            mapping[char] = target
+    return mapping
+
+
+def _projection_weights(model: Any, out_features: int) -> np.ndarray:
+    """Recover the final vocabulary projection matrix from the ONNX graph
+
+    docTR reads `projection.weight` off the `nn.Linear`. The ONNX graph has no modules, but the
+    projection survives as an initializer whose shape carries the vocabulary dimension, so it can
+    be located by shape and returned oriented as (out_features, hidden).
+
+    Args:
+        model: the recognition model
+        out_features: width of the logits, i.e. vocabulary size plus the special tokens
+
+    Returns:
+        the projection matrix of shape (out_features, hidden)
+    """
+    try:
+        import onnx
+        from onnx import numpy_helper
+    except ImportError:
+        raise ImportError(
+            "mapping='weights' reads the projection matrix out of the ONNX graph, which requires "
+            "the `onnx` package. Install it with `pip install onnx`, or use the default "
+            "mapping='anyascii'."
+        )
+
+    graph = onnx.load(str(model.model_path)).graph
+    candidates: list[tuple[str, np.ndarray]] = []
+    for initializer in graph.initializer:
+        array = numpy_helper.to_array(initializer)
+        if array.ndim == 2 and out_features in array.shape:
+            candidates.append((initializer.name, array))
+
+    if not candidates:
+        raise RuntimeError(f"Could not locate the vocabulary projection in the ONNX graph of {type(model).__name__}.")
+
+    # prefer an initializer whose name looks like the projection, else the last one in graph
+    # order (the projection sits at the very end of the network)
+    name, weights = candidates[-1]
+    for hint in _PROJECTION_HINTS:
+        match = [(n, a) for n, a in candidates if hint in n.lower()]
+        if match:
+            name, weights = match[0]
+            break
+
+    logger.debug(f"Using ONNX initializer '{name}' {weights.shape} as the vocabulary projection")
+    # orient as (out_features, hidden); a MatMul initializer is stored transposed
+    return weights if weights.shape[0] == out_features else weights.T
+
+
+def _weights_nearest_map(vocab: str, allowed: set[str], projection: np.ndarray) -> dict[str, str]:
+    """Map each forbidden character to the allowed one whose projection weights are most similar.
+
+    This uses the model's own learned representation: the nearest allowed character is the one
+    the model most confuses the forbidden character with (cosine similarity of the projection
+    weight rows).
+    """
+    vocab_size = len(vocab)
+    rows = projection[:vocab_size].astype(np.float32)
+    norms = np.linalg.norm(rows, axis=1, keepdims=True)
+    rows = rows / np.clip(norms, 1e-12, None)
+    allowed_idx = [i for i, char in enumerate(vocab) if char in allowed]
+    forbidden_idx = [i for i, char in enumerate(vocab) if char not in allowed]
+    if not allowed_idx or not forbidden_idx:
+        return {}
+    similarity = rows[forbidden_idx] @ rows[allowed_idx].T
+    nearest = similarity.argmax(axis=1)
+    return {vocab[forbidden_idx[k]]: vocab[allowed_idx[int(nearest[k])]] for k in range(len(forbidden_idx))}
+
+
+def _keep_and_reassign(
+    vocab: str, allowed: set[str], out_features: int, char_map: dict[str, str]
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Build the keep mask and the (forbidden -> allowed) index arrays for one projection."""
+    vocab_size = len(vocab)
+    keep = np.zeros(out_features, dtype=bool)
+    for idx, char in enumerate(vocab):
+        keep[idx] = char in allowed
+    # NOTE: every column past the vocabulary is a special token (CTC blank / attention <eos>,
+    # and for MASTER also <sos> and <pad>). All of them are kept so decoding still terminates.
+    keep[vocab_size:] = True
+
+    position = {char: idx for idx, char in enumerate(vocab)}
+    src, dst = [], []
+    for forbidden_char, allowed_char in char_map.items():
+        src_idx, dst_idx = position.get(forbidden_char), position.get(allowed_char)
+        # only reassign genuinely-forbidden characters onto genuinely-allowed ones
+        if src_idx is not None and dst_idx is not None and not keep[src_idx] and allowed_char in allowed:
+            src.append(src_idx)
+            dst.append(dst_idx)
+    return keep, np.asarray(src, dtype=np.int64), np.asarray(dst, dtype=np.int64)
+
+
+def add_whitelist(
+    model: Any,
+    vocabs: str | Iterable[str],
+    *,
+    strategy: str = "mask",
+    mapping: str | dict[str, str] | None = None,
+    verbose: bool = False,
+) -> WhitelistHandle:
+    """Restrict a recognition model so it can only predict a subset of its vocabulary.
+
+    The whitelist is enforced on the raw logits, right before they are decoded. docTR uses a
+    forward hook on the final projection layer; an ONNX graph has no hooks, so OnnxTR wraps the
+    recognition post-processor instead - the one point every architecture routes its logits
+    through. The sequence terminator (CTC `blank` / attention `<eos>`) and any other special
+    token are always kept so decoding still terminates. It works with every recognition
+    architecture and with any predictor wrapping one (`ocr_predictor`, `recognition_predictor`).
+
+    NOTE: for the autoregressive architectures (SAR, MASTER, PARSeq) the decoding loop lives
+    inside the ONNX graph, so the constraint applies to the emitted logits but cannot influence
+    what the graph feeds back to itself mid-word. For the CTC architectures (CRNN, VIPTR) and the
+    parallel decoders (ViTSTR) this is exactly equivalent to docTR's behaviour.
+
+    Two strategies are available:
+
+    - `"mask"` (default) simply forbids the characters outside the whitelist.
+    - `"nearest"` additionally folds each forbidden character onto the closest allowed one before
+      masking (so e.g. `ä` folds onto `a`).
+
+    A whitelist can only restrict a model to characters it already knows: characters that are
+    not part of the model's own vocabulary are silently ignored.
+
+    >>> from onnxtr.models import ocr_predictor
+    >>> from onnxtr.models.utils import add_whitelist
+    >>> from onnxtr.utils.vocabs import VOCABS
+    >>> predictor = ocr_predictor()
+    >>> handle = add_whitelist(predictor, [VOCABS["polish"], VOCABS["german"]])
+    >>> # ... run the predictor; only Polish/German characters can be predicted ...
+    >>> handle.remove()  # restore the original, unconstrained decoding
+
+    Args:
+        model: an `ocr_predictor`, `recognition_predictor`, or a recognition model.
+        vocabs: a vocabulary string (e.g. `VOCABS["german"]`) or an iterable of vocabulary
+            strings (e.g. `[VOCABS["polish"], VOCABS["german"]]`) whose characters are allowed.
+        strategy: `"mask"` (default) to drop forbidden characters, or `"nearest"` to fold
+            them onto the closest allowed character.
+        mapping: only used when `"strategy="nearest""`. `None` or `"anyascii"` builds the
+            forbidden-to-allowed map by transliteration (the default); `"weights"` derives it
+            from the projection weights read out of the ONNX graph (the model's own confusions);
+            a `dict` of `{forbidden_char: allowed_char}` overrides specific characters on top of
+            the transliteration map.
+        verbose: if True, log how many characters were kept, forbidden and reassigned per model.
+
+    Returns:
+        a :class:`WhitelistHandle`; call its :meth:`~WhitelistHandle.remove` method to restore
+        the original, unconstrained decoding.
+    """
+    if strategy not in {"mask", "nearest"}:
+        raise ValueError(f"Unknown strategy {strategy!r}; expected 'mask' or 'nearest'.")
+    if strategy == "mask" and mapping is not None:
+        raise ValueError("The 'mapping' argument is only used with strategy='nearest'.")
+    if isinstance(mapping, str) and mapping not in {"anyascii", "weights"}:
+        raise ValueError(f"Unknown mapping {mapping!r}; expected 'anyascii', 'weights', a dict or None.")
+    if mapping is not None and not isinstance(mapping, (str, dict)):
+        raise ValueError("The 'mapping' argument must be None, 'anyascii', 'weights' or a dict.")
+
+    allowed = set(vocabs) if isinstance(vocabs, str) else {char for vocab in vocabs for char in vocab}
+
+    restore: list[tuple[Any, Any]] = []
+    for reco_model in _recognition_models(model):
+        vocab: str = reco_model.cfg["vocab"]
+        vocab_size = len(vocab)
+        if not any(char in allowed for char in vocab):
+            raise ValueError(
+                "The whitelist shares no character with the model's vocabulary; the model would "
+                "be unable to predict anything."
+            )
+
+        out_features = _logits_width(reco_model, vocab_size)
+
+        char_map: dict[str, str] = {}
+        if strategy == "nearest":
+            if mapping == "weights":
+                char_map = _weights_nearest_map(vocab, allowed, _projection_weights(reco_model, out_features))
+            else:
+                char_map = _anyascii_nearest_map(vocab, allowed)
+                if isinstance(mapping, dict):
+                    char_map = {**char_map, **mapping}
+
+        keep, src, dst = _keep_and_reassign(vocab, allowed, out_features, char_map)
+
+        restore.append((reco_model, reco_model.postprocessor))
+        reco_model.postprocessor = _ConstrainedPostProcessor(reco_model.postprocessor, keep, src, dst)
+
+        if verbose:  # pragma: no cover
+            kept = sum(char in allowed for char in vocab)
+            logger.info(
+                f"add_whitelist: {type(reco_model).__name__} - kept {kept}/{vocab_size} vocabulary "
+                f"characters, forbade {vocab_size - kept}"
+                + (f", reassigned {src.size} to a nearest allowed character." if strategy == "nearest" else ".")
+            )
+
+    return WhitelistHandle(restore)
+
+
+def _logits_width(model: Any, vocab_size: int) -> int:
+    """Width of the model's logits, i.e. the vocabulary plus its special tokens
+
+    Read from the graph's output metadata when it is static (all architectures declare it), and
+    otherwise assumed to be the vocabulary plus a single terminator.
+    """
+    for output in model.runtime.get_outputs():
+        last_dim = output.shape[-1] if output.shape else None
+        if isinstance(last_dim, int) and last_dim >= vocab_size:
+            return last_dim
+    return vocab_size + 1  # pragma: no cover

--- a/onnxtr/utils/data.py
+++ b/onnxtr/utils/data.py
@@ -17,6 +17,7 @@ from tqdm.auto import tqdm
 
 __all__ = ["download_from_url"]
 
+logger = logging.getLogger(__name__)
 
 # matches bfd8deac from resnet18-bfd8deac.ckpt
 HASH_REGEX = re.compile(r"-([a-f0-9]*)\.")
@@ -84,7 +85,7 @@ def download_from_url(
     file_path = folder_path.joinpath(file_name)
     # Check file existence
     if file_path.is_file() and (hash_prefix is None or _check_integrity(file_path, hash_prefix)):
-        logging.info(f"Using downloaded & verified file: {file_path}")
+        logger.info(f"Using downloaded & verified file: {file_path}")
         return file_path
 
     try:
@@ -98,7 +99,7 @@ def download_from_url(
             error_message += (
                 ". You can change default cache directory using 'ONNXTR_CACHE_DIR' environment variable if needed."
             )
-        logging.error(error_message)
+        logger.error(error_message)
         raise
     # Download the file
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ testing = [
     "requests>=2.20.0",
     "pytest-memray>=1.7.0",
     "psutil>=7.0.0",
+    "onnx>=1.18.0",
     "pandas>=2.0.0",
 ]
 quality = [
@@ -104,6 +105,7 @@ dev = [
     "requests>=2.20.0",
     "pytest-memray>=1.7.0",
     "psutil>=7.0.0",
+    "onnx>=1.18.0",
     "pandas>=2.0.0",
     # Quality
     "ruff>=0.1.5",

--- a/tests/common/test_models_utils.py
+++ b/tests/common/test_models_utils.py
@@ -1,0 +1,206 @@
+import numpy as np
+import pytest
+
+from onnxtr.models import ocr_predictor, recognition
+from onnxtr.models.preprocessor import PreProcessor
+from onnxtr.models.recognition.predictor import RecognitionPredictor
+from onnxtr.models.utils import (
+    WhitelistHandle,
+    _anyascii_nearest_map,
+    _keep_and_reassign,
+    _logits_width,
+    _projection_weights,
+    _weights_nearest_map,
+    add_whitelist,
+)
+
+
+def _predictor(arch_name):
+    model = recognition.__dict__[arch_name]()
+    return RecognitionPredictor(PreProcessor((32, 128), batch_size=4, preserve_aspect_ratio=True), model), model
+
+
+class _LogitRecorder:
+    """Stands in for the real post-processor so the constrained logits can be inspected."""
+
+    def __init__(self, postprocessor):
+        self.postprocessor = postprocessor
+        self.logits = None
+
+    def __call__(self, logits, *args, **kwargs):
+        self.logits = logits
+        return self.postprocessor(logits, *args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "arch_name",
+    [
+        "crnn_mobilenet_v3_small",
+        "vitstr_small",
+        "viptr_tiny",
+        "master",  # 3 special tokens instead of 1
+    ],
+)
+def test_add_whitelist(arch_name):
+    predictor, model = _predictor(arch_name)
+    vocab = model.cfg["vocab"]
+    # a whitelist that is a strict subset of the model's own vocabulary
+    _whitelist = "abcdefghijklmnopqrstuvwxyz "
+    allowed = {char for char in _whitelist if char in vocab}
+    assert allowed  # sanity: the model knows these characters
+
+    forbidden_idx = [i for i, c in enumerate(vocab) if c not in allowed]
+    allowed_idx = [i for i, c in enumerate(vocab) if c in allowed]
+    terminator_idx = len(vocab)
+    assert len(forbidden_idx) > 0
+
+    samples = [(255 * np.random.rand(32, 128, 3)).astype(np.uint8) for _ in range(4)]
+
+    # record what the post-processor actually receives once the whitelist is installed
+    recorder = _LogitRecorder(model.postprocessor)
+    model.postprocessor = recorder
+
+    handle = add_whitelist(predictor, _whitelist)
+    assert isinstance(handle, WhitelistHandle)
+    preds = predictor(samples)
+    logits = recorder.logits
+
+    # forbidden characters are masked out, while whitelisted characters and the terminator stay finite
+    assert np.isneginf(logits[..., forbidden_idx]).all()
+    assert np.isfinite(logits[..., allowed_idx]).all()
+    assert np.isfinite(logits[..., terminator_idx]).all()
+    # every column past the vocabulary is a special token and must stay finite so decoding ends
+    assert np.isfinite(logits[..., len(vocab) :]).all()
+    # the decoded output only contains whitelisted characters (and no leaked special tokens)
+    for word, _ in preds:
+        assert all(char in allowed for char in word)
+
+    # remove() restores the original, unconstrained decoding
+    handle.remove()
+    _ = predictor(samples)
+    assert np.isfinite(recorder.logits).all()
+
+
+@pytest.mark.parametrize("arch_name", ["crnn_mobilenet_v3_small", "vitstr_small"])
+def test_add_whitelist_changes_prediction(arch_name):
+    predictor, model = _predictor(arch_name)
+    from conftest import synthesize_text_img
+
+    img = np.asarray(synthesize_text_img("12345", background_color=(255, 255, 255), text_color=(0, 0, 0)))
+    baseline = predictor([img])[0][0]
+    assert "1" in baseline
+
+    with add_whitelist(predictor, "023456789"):  # '1' deliberately absent
+        constrained = predictor([img])[0][0]
+    assert "1" not in constrained
+    # the context manager restored the original behaviour
+    assert predictor([img])[0][0] == baseline
+
+
+def test_add_whitelist_is_removable_via_context_manager():
+    predictor, model = _predictor("crnn_mobilenet_v3_small")
+    original = model.postprocessor
+    with add_whitelist(predictor, "abc"):
+        assert model.postprocessor is not original
+    assert model.postprocessor is original
+
+
+def test_add_whitelist_nearest_folds_to_base():
+    _, model = _predictor("crnn_mobilenet_v3_small")
+    vocab = model.cfg["vocab"]
+    width = _logits_width(model, len(vocab))
+    allowed = set("abcou")
+
+    char_map = _anyascii_nearest_map(vocab, allowed)
+    assert char_map.get("A") == "a"
+
+    keep, src, dst = _keep_and_reassign(vocab, allowed, width, char_map)
+    from onnxtr.models.utils import _ConstrainedPostProcessor
+
+    constrainer = _ConstrainedPostProcessor(lambda x: x, keep, src, dst)
+
+    logits = np.zeros((1, 1, width), dtype=np.float32)
+    logits[0, 0, vocab.index("A")] = 9.0  # the model strongly wants a forbidden 'A'
+    out = constrainer._constrain(logits)
+
+    assert out[0, 0, vocab.index("a")] == 9.0  # folded onto the allowed base
+    assert np.isneginf(out[0, 0, vocab.index("A")])  # and the forbidden column is masked
+    assert vocab[int(np.argmax(out[0, 0, : len(vocab)]))] == "a"
+
+    # mask-only does not fold: the score is simply dropped
+    keep, src, dst = _keep_and_reassign(vocab, allowed, width, {})
+    out = _ConstrainedPostProcessor(lambda x: x, keep, src, dst)._constrain(logits)
+    assert out[0, 0, vocab.index("a")] == 0.0
+
+
+def test_add_whitelist_nearest_custom_mapping():
+    _, model = _predictor("crnn_mobilenet_v3_small")
+    vocab = model.cfg["vocab"]
+    width = _logits_width(model, len(vocab))
+    allowed = set("abcou")
+
+    char_map = {**_anyascii_nearest_map(vocab, allowed), "A": "b"}  # override A -> b
+    keep, src, dst = _keep_and_reassign(vocab, allowed, width, char_map)
+    from onnxtr.models.utils import _ConstrainedPostProcessor
+
+    logits = np.zeros((1, 1, width), dtype=np.float32)
+    logits[0, 0, vocab.index("A")] = 9.0
+    out = _ConstrainedPostProcessor(lambda x: x, keep, src, dst)._constrain(logits)
+    assert out[0, 0, vocab.index("b")] == 9.0
+    assert out[0, 0, vocab.index("a")] == 0.0
+
+
+def test_add_whitelist_nearest_weights_stays_within_whitelist():
+    _, model = _predictor("crnn_mobilenet_v3_small")
+    vocab = model.cfg["vocab"]
+    width = _logits_width(model, len(vocab))
+    allowed = set("abcou")
+
+    projection = _projection_weights(model, width)
+    assert projection.shape[0] == width  # oriented as (out_features, hidden)
+
+    char_map = _weights_nearest_map(vocab, allowed, projection)
+    assert char_map  # something was mapped
+    assert all(target in allowed for target in char_map.values())
+    assert all(source not in allowed for source in char_map)
+
+
+def test_add_whitelist_end_to_end():
+    predictor = ocr_predictor(reco_arch="crnn_mobilenet_v3_small", det_bs=1)
+    page = (255 * np.ones((300, 900, 3))).astype(np.uint8)
+    with add_whitelist(predictor, "0123456789"):
+        out = predictor([page])
+    for block in out.pages[0].blocks:
+        for line in block.lines:
+            for word in line.words:
+                assert all(char in "0123456789" for char in word.value)
+
+
+def test_add_whitelist_errors():
+    predictor, _ = _predictor("crnn_mobilenet_v3_small")
+    # unknown strategy
+    with pytest.raises(ValueError):
+        add_whitelist(predictor, "abc", strategy="unknown")
+    # mapping is meaningless without strategy='nearest'
+    with pytest.raises(ValueError):
+        add_whitelist(predictor, "abc", strategy="mask", mapping="anyascii")
+    # unknown mapping
+    with pytest.raises(ValueError):
+        add_whitelist(predictor, "abc", strategy="nearest", mapping="unknown")
+    # a whitelist sharing nothing with the model vocabulary
+    with pytest.raises(ValueError):
+        add_whitelist(predictor, "中文")
+    # not a predictor nor a recognition model
+    with pytest.raises(TypeError):
+        add_whitelist(object(), "abc")
+
+
+def test_add_whitelist_accepts_multiple_vocabs():
+    predictor, model = _predictor("crnn_mobilenet_v3_small")
+    handle = add_whitelist(predictor, ["abc", "123"])
+    keep = model.postprocessor.keep
+    vocab = model.cfg["vocab"]
+    for char in "abc123":
+        assert keep[vocab.index(char)]
+    assert not keep[vocab.index("z")]
+    handle.remove()

--- a/tests/common/test_utils_data.py
+++ b/tests/common/test_utils_data.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 from pathlib import PosixPath
@@ -36,22 +37,22 @@ def test_download_from_url_customizing_cache_dir(mkdir_mock, urlretrieve_mock):
 
 @patch.dict(os.environ, {"HOME": "/"}, clear=True)
 @patch("pathlib.Path.mkdir", side_effect=OSError)
-@patch("logging.error")
-def test_download_from_url_error_creating_directory(logging_mock, mkdir_mock):
-    with pytest.raises(OSError):
-        download_from_url("test_url")
-    logging_mock.assert_called_with(
-        "Failed creating cache direcotry at /.cache/onnxtr."
+def test_download_from_url_error_creating_directory(mkdir_mock, caplog):
+    with caplog.at_level(logging.ERROR, logger="onnxtr.utils.data"):
+        with pytest.raises(OSError):
+            download_from_url("test_url")
+    assert (
+        "Failed creating cache directory at /.cache/onnxtr."
         " You can change default cache directory using 'ONNXTR_CACHE_DIR' environment variable if needed."
-    )
+    ) in caplog.text
 
 
 @patch.dict(os.environ, {"HOME": "/", "ONNXTR_CACHE_DIR": "/test"}, clear=True)
 @patch("pathlib.Path.mkdir", side_effect=OSError)
-@patch("logging.error")
-def test_download_from_url_error_creating_directory_with_env_var(logging_mock, mkdir_mock):
-    with pytest.raises(OSError):
-        download_from_url("test_url")
-    logging_mock.assert_called_with(
-        "Failed creating cache direcotry at /test using path from 'ONNXTR_CACHE_DIR' environment variable."
-    )
+def test_download_from_url_error_creating_directory_with_env_var(mkdir_mock, caplog):
+    with caplog.at_level(logging.ERROR, logger="onnxtr.utils.data"):
+        with pytest.raises(OSError):
+            download_from_url("test_url")
+    assert (
+        "Failed creating cache directory at /test using path from 'ONNXTR_CACHE_DIR' environment variable."
+    ) in caplog.text

--- a/tests/common/test_utils_data.py
+++ b/tests/common/test_utils_data.py
@@ -41,8 +41,9 @@ def test_download_from_url_error_creating_directory(mkdir_mock, caplog):
     with caplog.at_level(logging.ERROR, logger="onnxtr.utils.data"):
         with pytest.raises(OSError):
             download_from_url("test_url")
+    assert "Failed creating cache" in caplog.text
     assert (
-        "Failed creating cache directory at /.cache/onnxtr."
+        "at /.cache/onnxtr."
         " You can change default cache directory using 'ONNXTR_CACHE_DIR' environment variable if needed."
     ) in caplog.text
 
@@ -53,6 +54,5 @@ def test_download_from_url_error_creating_directory_with_env_var(mkdir_mock, cap
     with caplog.at_level(logging.ERROR, logger="onnxtr.utils.data"):
         with pytest.raises(OSError):
             download_from_url("test_url")
-    assert (
-        "Failed creating cache directory at /test using path from 'ONNXTR_CACHE_DIR' environment variable."
-    ) in caplog.text
+    assert "Failed creating cache" in caplog.text
+    assert ("at /test using path from 'ONNXTR_CACHE_DIR' environment variable.") in caplog.text


### PR DESCRIPTION
This pull request primarily introduces a new utility module for constraining recognition model outputs to a whitelist of allowed characters, and standardizes logging practices across the codebase. The most significant changes are the addition of `onnxtr/models/utils.py` with the `add_whitelist` functionality, and the replacement of direct `logging` calls with module-level loggers in several files for improved logging consistency.

**New recognition model utility:**

* Added `onnxtr/models/utils.py` with `add_whitelist`, enabling restriction of recognition models to a set of allowed vocabulary characters, supporting both "mask" and "nearest" strategies, and providing a context-managed `WhitelistHandle` for reversible application. This includes logic for mapping forbidden characters to allowed ones via transliteration or projection weights, and applies to any compatible recognition model or predictor. (`[onnxtr/models/utils.pyR1-R333](diffhunk://#diff-f6d3ad3087132a5c4c078c1e4ad2eb45fa1b4c347fc9befeb82b52ce38babda4R1-R333)`)

* Exposed all public symbols from `onnxtr/models/utils.py` in the `onnxtr.models` package by adding `from .utils import *` to `onnxtr/models/__init__.py`. (`[onnxtr/models/__init__.pyR10](diffhunk://#diff-1aa1abb6cf88f7bdd2cf8e24e294267e75f5cf202988474eb7c5924d26b2d687R10)`)

**Logging improvements:**

* Replaced direct `logging` calls with module-level `logger = logging.getLogger(__name__)` in multiple modules, including `file_utils.py`, `models/detection/models/fast.py`, `models/layout/models/lw_detr.py`, `models/recognition/models/viptr.py`, `models/table_structure/models/tablecenternet.py`, `models/engine.py`, and `utils/data.py`. All logging statements in these files now use the local `logger`. (`[[1]](diffhunk://#diff-704d59a604e12f75cd1b2bdeec30adf6209ca91ed39d68516ff55302b57d5fc6R11-R12)`, `[[2]](diffhunk://#diff-4f9bc97301c19393df2c661e77f1e2c92daa31fcb84e07e681f4c56d39e09a04R17-R18)`, `[[3]](diffhunk://#diff-d304546f6c0be200ba42e162372987a8b5fced37c35476035ec30104355cd220R18)`, `[[4]](diffhunk://#diff-4d6e46ba702f1be2d99f92e091fbd6d1dfcdfd8f5f33fdd79449bb09b716fb7aR21-R22)`, `[[5]](diffhunk://#diff-1a2c61acd62862635adfe40ad97a28f1b4745b749af851ccef625b020e21de8bR22-R23)`, `[[6]](diffhunk://#diff-8e66aa6c2b335b6c3a565217c86853cf8893d62583921b0946421571efb3e2ebR30-R31)`, `[[7]](diffhunk://#diff-8ac5038e800f5385ad6dd979d648d1e610dc99745c2a3d552da57b6926a1d8a4R20)`)

* Updated all affected logging calls in the above files to use the new `logger` variable instead of the global `logging` module. (`[[1]](diffhunk://#diff-704d59a604e12f75cd1b2bdeec30adf6209ca91ed39d68516ff55302b57d5fc6L25-R27)`, `[[2]](diffhunk://#diff-4f9bc97301c19393df2c661e77f1e2c92daa31fcb84e07e681f4c56d39e09a04L99-R101)`, `[[3]](diffhunk://#diff-d304546f6c0be200ba42e162372987a8b5fced37c35476035ec30104355cd220L148-R149)`, `[[4]](diffhunk://#diff-4d6e46ba702f1be2d99f92e091fbd6d1dfcdfd8f5f33fdd79449bb09b716fb7aL142-R144)`, `[[5]](diffhunk://#diff-1a2c61acd62862635adfe40ad97a28f1b4745b749af851ccef625b020e21de8bL239-R241)`, `[[6]](diffhunk://#diff-8e66aa6c2b335b6c3a565217c86853cf8893d62583921b0946421571efb3e2ebL72-R74)`, `[[7]](diffhunk://#diff-8ac5038e800f5385ad6dd979d648d1e610dc99745c2a3d552da57b6926a1d8a4L87-R88)`, `[[8]](diffhunk://#diff-8ac5038e800f5385ad6dd979d648d1e610dc99745c2a3d552da57b6926a1d8a4L101-R102)`)